### PR TITLE
fix: canvas options to extend correct parent type

### DIFF
--- a/src/QRCodeCanvas.ts
+++ b/src/QRCodeCanvas.ts
@@ -1,9 +1,9 @@
-import type {
-  OptionsType as ParentOptionsType,
-  QRCodeDataType,
-} from './QRCodeRaw';
+import type { QRCodeDataType } from './QRCodeRaw';
 import ColorUtils from './utils/ColorUtils';
-import type { ImageConfigType } from './AbstractQRCodeWithImage';
+import type {
+  ImageConfigType,
+  OptionsType as ParentOptionsType,
+} from './AbstractQRCodeWithImage';
 import AbstractQRCodeWithImage from './AbstractQRCodeWithImage';
 import { loadImage } from './loader/ImageLoader';
 


### PR DESCRIPTION
QRCodeCanvas extends AbstractQRCodeWithImage and it should be typed
with AbstractQRCodeWithImage's options as parent type.
